### PR TITLE
feat: added mising CodeDeploy scripts to python-url-shortner

### DIFF
--- a/python-url-shortner/appspec.yml
+++ b/python-url-shortner/appspec.yml
@@ -6,27 +6,27 @@ os: linux
 
 # file to copy on each deployment
 files:
-# Directory to copy in each application revision
-- source: /
-destination: /app
+  # Directory to copy in each application revision
+  - source: /
+    destination: /app
+file_exists_behavior: OVERWRITE
 
 # section for defining the scripts to be run on Lifecycle events
 hooks:
+  BeforeInstall:
+     # location to bash script for installing docker and docker-compose
+    - location: install_docker.sh
+      # grant the code deploy agent root permission
+      runas: root
 
-BeforeInstall:
- # location to bash script for installing docker and docker-compose
-- location: config/install_docker.sh
-# grant the code deploy agent root permission
-runas: root
+  # lifecycle event with script to start application
+  ApplicationStart:
+    - location: start-app.sh
+      timeout: 3600
+      runas: root
 
-# lifecycle event with script to start application
-ApplicationStart:
-  - location: config/start-app.sh
-timeout: 3600
-runas: root
-
-# lifecycle event with script to stop running application
-ApplicationStop:
-- location: config/stop-app.sh
-timeout: 2000
-runas: root
+  # lifecycle event with script to stop running application
+  ApplicationStop:
+    - location: stop-app.sh
+      timeout: 2000
+      runas: root

--- a/python-url-shortner/install_docker.sh
+++ b/python-url-shortner/install_docker.sh
@@ -1,4 +1,4 @@
-#!*/bin/bash*
+#!/bin/bash
 
 # update VM apt repository
 apt-get update
@@ -9,11 +9,8 @@ apt-get -y install apt-transport-https ca-certificates lsb-release
 # add docker GPG key
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
 
-echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu \
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-
-# update VM apt repository after adding docker
 apt-get update
 
 # install docker community edition and cli

--- a/python-url-shortner/requirements.txt
+++ b/python-url-shortner/requirements.txt
@@ -9,3 +9,4 @@ shortuuid==1.0.1
 starlette==0.14.2
 typing-extensions==3.10.0.0
 uvicorn==0.14.0
+requests==2.26.0

--- a/python-url-shortner/routes.py
+++ b/python-url-shortner/routes.py
@@ -5,6 +5,7 @@ from pydantic import BaseModel
 import datetime
 import shortuuid
 import os
+from requests import get
 
 app = FastAPI()
 client = MongoClient(os.environ.get('MONGO_URI'))
@@ -37,10 +38,15 @@ class UrlModel(BaseModel):
 # Insert long_url to database
 @app.post("/shorty")
 def url(url: UrlModel, response: Response):
-    print(url)
     if url is not None and type(url.url) == str:
         url_id = shortuuid.uuid()
-        short_url = "http://localhost:8000/{0}".format(url_id)
+
+        """
+        Retrieve the External Public IP of whatever machine is running python app.
+        This is done temporarily so that the application can redirect back to the shortened URL. Permanent fix is to setup DNS routing
+        """ 
+        etxernalIp = get('https://api.ipify.org').content.decode('utf8')
+        short_url = "http://{0}:8000/{1}".format(etxernalIp, url_id)
 
         data = {
             "long_url": url.url,

--- a/python-url-shortner/start-app.sh
+++ b/python-url-shortner/start-app.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /app
+
+docker-compose up --build -d

--- a/python-url-shortner/start.sh
+++ b/python-url-shortner/start.sh
@@ -1,2 +1,0 @@
-#!*/bin/bash*
-docker-compose up --build

--- a/python-url-shortner/stop-app.sh
+++ b/python-url-shortner/stop-app.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cd /app
+
+docker-compose down

--- a/python-url-shortner/stop.sh
+++ b/python-url-shortner/stop.sh
@@ -1,2 +1,0 @@
-#!*/bin/bash*
-docker-compose down


### PR DESCRIPTION
@alistek I found some more items that needed correction within the cloned `python-url-shortner` folder. They are; 

- The `appspec.yml` was wrongly formated
- The `stop.sh` file should have been named `stop-app.sh`
- The `start.sh` file should have been named `start-app.sh`
- A few corrections to the python application